### PR TITLE
docs: remove docker hub access token references

### DIFF
--- a/src/how-to/set-up/create-docker-hub-access-token.md
+++ b/src/how-to/set-up/create-docker-hub-access-token.md
@@ -1,8 +1,0 @@
-# Creating a Docker Hub Access Token
-
-During the initial AppPack set up, you'll be prompted for a Docker Hub username and access token. These are required to download the base images for the [Heroku buildpacks](https://hub.docker.com/u/heroku) used by AppPack while avoiding [Docker Hub's anonymous download rate limits](https://docs.docker.com/docker-hub/download-rate-limit/).
-
-1. Create a free Personal account at [https://hub.docker.com/signup](https://hub.docker.com/signup)
-2. Click "New Access Token" at [https://hub.docker.com/settings/security](https://hub.docker.com/settings/security)
-3. In the pop-up, give your token a description ("apppack" is fine), select `Public Repo Read-only`, and click "Generate"
-4. Copy the person access token (it should start with `dckr_pat_`)

--- a/src/tutorials/initial-setup.md
+++ b/src/tutorials/initial-setup.md
@@ -8,7 +8,6 @@ You'll need a few things ready to go to complete this tutorial. Make sure you've
 
 1. Installed **the `apppack` CLI** (see _[Install the CLI](../how-to/set-up/install.md)_)
 2. Setup **an AWS account** with access to an admin user or role.
-3. Create a [free Docker Hub account and generate an access token](../how-to/set-up/create-docker-hub-access-token.md).
 
 
 ## 🏗 Setting up AWS resources
@@ -96,10 +95,7 @@ apppack create cluster
 ```
 <script id="asciicast-9MQqww0ej7qAMhLjvM708mh00" src="https://asciinema.org/a/9MQqww0ej7qAMhLjvM708mh00.js" data-rows="20" data-theme="monokai" async></script>
 
-You'll get a confirmation prompt about the region where the cluster will be installed. Type `yes` and you'll be prompted for:
-
-1. Your Docker Hub username and access token
-2. Your domain you created above
+You'll get a confirmation prompt about the region where the cluster will be installed. Type `yes` and you'll be prompted for the domain you created above.
 
 This should run for about 10 minutes while AWS creates all the necessary resources.
 

--- a/src/under-the-hood/index.md
+++ b/src/under-the-hood/index.md
@@ -17,8 +17,7 @@ During setup, you'll create multiple Cloudformation Stacks for different resourc
 At the account level we setup:
 
 * An [IAM OIDC provider](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc.html) which will allow users to login to AppPack and exchange those credentials for limited time tokens to manage the application.
-* [Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html) values for your Docker Hub credentials. These are created directly via the CLI [because `SecureString` credentials cannot be created by Cloudformation](https://github.com/aws-cloudformation/aws-cloudformation-coverage-roadmap/issues/82).
-* An EventBridge rule to monitor changes to the Parameter Store. These events only include the name of the Parameter, not the value and any value that doesn't match AppPack's prefix is ignored.
+* An EventBridge rule to monitor changes to [Parameter Store](https://docs.aws.amazon.com/systems-manager/latest/userguide/systems-manager-parameter-store.html). These events only include the name of the Parameter, not the value and any value that doesn't match AppPack's prefix is ignored.
 * An IAM Role that is used by AppPack to collect further data on events that do not include enough information to know what app they belong to. These include:
   * [ECS Task state change](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwe_events.html#ecs_task_events) events
   * [ECS Service action](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs_cwe_events.html#ecs_service_events) events


### PR DESCRIPTION
## Summary
- Remove the "Create a Docker Hub account and generate an access token" prerequisite step and the corresponding prompt reference in the initial setup tutorial
- Delete the now-orphaned "Creating a Docker Hub Access Token" how-to page
- Remove the stale mention of Docker Hub credentials being stored in Parameter Store during account setup

## Why
The `apppack` CLI no longer prompts for Docker Hub credentials during `apppack create cluster` (verified in `stacks/cluster.go` / `stacks/region.go` in the `apppack` CLI repo) — only the cluster domain is asked for. The old SSM parameter is only referenced during stack teardown as legacy cleanup, not created during setup.

Closes #23

## Test plan
- [x] Verified no remaining "docker hub" / "dockerhub" references anywhere in the docs source
- [x] Verified no other page links to the deleted how-to page